### PR TITLE
Correct spelling of 'seperator' to 'separator'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var gitshasuffix = require("gulp-gitshasuffix");
 var files = gulp.src("./src/*.ext")
 	.pipe(gitshasuffix({
     length: 6,
-    seperator: "-"
+    separator: "-"
   }))
 
 files.on('data', function (file){
@@ -56,11 +56,11 @@ Default: 6
 
 Length of the sha to show.
 
-#### options.seperator
+#### options.separator
 Type: `String`  
 Default: "-"
 
-Seperator before the suffix.
+Separator before the suffix.
 
 #### options.folder
 Type: `Boolean`  

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (options) {
 
   options = options || {};
   var length = options.length || 6;
-  var seperator = options.seperator || "-";
+  var separator = options.separator || options.seperator || "-";
   var folder = !!options.folder;
 
   var gitshasuffix = function (file, enc, callback) {
@@ -22,7 +22,7 @@ module.exports = function (options) {
 
     var appendSuffix = function () {
       var shaSuffix = sha.substring(0, length),
-          finalSuffix = seperator + shaSuffix;
+          finalSuffix = separator + shaSuffix;
 
       if (file.isNull()) {
         file.path = file.path + finalSuffix;

--- a/test/main.js
+++ b/test/main.js
@@ -43,7 +43,7 @@ describe("gulp-gitmodified", function () {
     instream.pipe(outstream);
   });
 
-  it('should default to - as seperator and the first 6 characters', function(done) {
+  it('should default to - as separator and the first 6 characters', function(done) {
     var testSha = "fbb790d601f7cb0ad0fabe5feff023b02aa9a03d",
         instream = gulp.src(join(__dirname, "./fixtures/a.txt")),
         outstream = suffix();
@@ -112,13 +112,13 @@ describe("gulp-gitmodified", function () {
     instream.pipe(outstream);
   });
 
-  it('should take seperator as argument', function(done) {
+  it('should take separator as argument', function(done) {
     var testSha = "fbb790d601f7cb0ad0fabe5feff023b02aa9a03d",
-        seperator = "***",
+        separator = "***",
         instream = gulp.src(join(__dirname, "./fixtures/a.txt")),
         outstream = suffix({
           length: 6,
-          seperator: seperator
+          separator: separator
         });
 
     git.getLatestSha = function (cb) {
@@ -126,8 +126,37 @@ describe("gulp-gitmodified", function () {
     };
 
     outstream.on('data', function(file) {
-      should.exist(file.relative.indexOf(seperator) !== -1);
-      var split = file.relative.split(seperator);
+      should.exist(file.relative.indexOf(separator) !== -1);
+      var split = file.relative.split(separator);
+      should.exist(file);
+      should.exist(file.path);
+      should.exist(split);
+      should.exist(split[1]);
+      split.length.should.equal(2);
+      split[1].should.equal(testSha.substring(0, 6) + ".txt");
+      done();
+    });
+
+    instream.pipe(outstream);
+  });
+
+
+  it('should take seperator as argument', function(done) {
+    var testSha = "fbb790d601f7cb0ad0fabe5feff023b02aa9a03d",
+        separator = "***",
+        instream = gulp.src(join(__dirname, "./fixtures/a.txt")),
+        outstream = suffix({
+          length: 6,
+          seperator: separator
+        });
+
+    git.getLatestSha = function (cb) {
+      return cb(null, testSha);
+    };
+
+    outstream.on('data', function(file) {
+      should.exist(file.relative.indexOf(separator) !== -1);
+      var split = file.relative.split(separator);
       should.exist(file);
       should.exist(file.path);
       should.exist(split);
@@ -142,11 +171,11 @@ describe("gulp-gitmodified", function () {
 
   it('should set suffix on all files', function(done) {
     var testSha = "fbb790d601f7cb0ad0fabe5feff023b02aa9a03d",
-        seperator = "***",
+        separator = "***",
         instream = gulp.src(join(__dirname, "./fixtures/*")),
         outstream = suffix({
           length: 6,
-          seperator: seperator
+          separator: separator
         });
 
     git.getLatestSha = function (cb) {
@@ -155,8 +184,8 @@ describe("gulp-gitmodified", function () {
 
     outstream.on('data', function(file) {
       var ext = path.extname(file.path);
-      should.exist(file.relative.indexOf(seperator) !== -1);
-      var split = file.relative.split(seperator);
+      should.exist(file.relative.indexOf(separator) !== -1);
+      var split = file.relative.split(separator);
       should.exist(file);
       should.exist(file.path);
       should.exist(split);


### PR DESCRIPTION
I really want to use this plugin but I'm too OCD to deal with spelling errors in my code. This change won't break existing code but will allow the use of the correct spelling 'separator'.
